### PR TITLE
Add PyPI classifiers to setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,95 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# PyCharm project settings
+.idea

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.rst') as infile:
 
 setup(
     version=__version__,
-    url="https://github.com/astrofrog/pytest-fits",
+    url="https://github.com/astrofrog/pytest-arraydiff",
     name="pytest-arraydiff",
     description='pytest plugin to help with comparing array output from tests',
     long_description=long_description,
@@ -22,4 +22,15 @@ setup(
     author='Thomas Robitaille',
     author_email='thomas.robitaille@gmail.com',
     entry_points={'pytest11': ['pytest_arraydiff = pytest_arraydiff.plugin']},
-    )
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Framework :: Pytest',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Testing',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        'Operating System :: OS Independent',
+        'License :: OSI Approved :: BSD License',
+    ],
+)


### PR DESCRIPTION
This PR adds PyPI classifiers to setup.py

Especially "Framework :: Pytest" is useful IMO, it let's people find it as a Pytest plugin, see:
http://doc.pytest.org/en/latest/writing_plugins.html#making-your-plugin-installable-by-others
https://github.com/pytest-dev/cookiecutter-pytest-plugin/blob/master/pytest-%7B%7Bcookiecutter.plugin_name%7D%7D/setup.py#L27

I've also fixed `url="https://github.com/astrofrog/pytest-arraydiff"` so that it's easier to find the Github repo from the PyPI page and added a `.gitignore` file (standard Python project template from PyCharm).