### PR TITLE
Rename FITSDiff tolerance parameter to reflect changes in astropy 2.0

### DIFF
--- a/pytest_arraydiff/plugin.py
+++ b/pytest_arraydiff/plugin.py
@@ -122,7 +122,7 @@ class FITSDiff(BaseDiff):
     @classmethod
     def compare(cls, reference_file, test_file, atol=None, rtol=None):
         from astropy.io.fits.diff import FITSDiff
-        diff = FITSDiff(reference_file, test_file, tolerance=rtol)
+        diff = FITSDiff(reference_file, test_file, rtol=rtol)
         return diff.identical, diff.report()
 
 


### PR DESCRIPTION
Tests against astropy dev in reproject are failing as pytest-arraydiff generates a deprecation warning.